### PR TITLE
Fix Uint8Array detection for vitest w/ jsdom

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -24,7 +24,7 @@ export const digest = (tree, hash = sha256) => {
   } else {
     const leaves = []
     for (const node of tree) {
-      if (node instanceof Uint8Array) {
+      if (node.BYTES_PER_ELEMENT === 1) {
         leaves.push(node)
       } else {
         leaves.push(digest(node, hash))


### PR DESCRIPTION
Use BYTES_PER_ELEMENT property instead of instanceof Uint8Array to identify the latter

vitest and maybe other test environments that can use jsdom were broken before, because the node provider Uint8Array is different from the window provided one. This way of identifying Uint8Array works either way.